### PR TITLE
Remove utf16 chars from data usage report

### DIFF
--- a/dxskytap/reports.py
+++ b/dxskytap/reports.py
@@ -82,7 +82,8 @@ class UsageReport(RestObject):
         """
         contents = self._connect.request(self.url, 'GET',
                accept_type='application/csv')
-        return csv.DictReader(contents.split('\n'))
+        cleanData = contents.encode('ascii', 'ignore')
+        return csv.DictReader(cleanData.split('\n'))
 
 class Reports(object):
     """


### PR DESCRIPTION
Problem with CSV Reader and UTF-16 data. Remove UTf-16 characters so CSV Reader can work with the data.
