### PR TITLE
[BT-1851] fix report api

### DIFF
--- a/dxskytap/connect.py
+++ b/dxskytap/connect.py
@@ -122,7 +122,7 @@ class Connect(object):
     def _makeurl(self, resource):
         return urljoin(self.base_url, resource)
 
-    def request(self, url, method, params, body=None, headers=None,
+    def request(self, url, method, params=None, body=None, headers=None,
                 accept_type='application/json'):
         """
         HTTP request. Default handling uses 'application/json' for

--- a/dxskytap/reports.py
+++ b/dxskytap/reports.py
@@ -95,6 +95,18 @@ class Reports(object):
 
     def generate_usage_report(self, start_date, end_date, resource_type='svms',
             utc=True, region='all', group_by='raw', aggregate_by='none'):
+        """
+        Generate Report for Storage or SVM usage from history data
+        
+        Parameters
+            start_date
+            end_date
+            utc - boolean, if true use UTC time
+            resource_type - 'storage' or 'svms'
+            region - 'all', 'US-East', 'US-West', etc...
+            group_by - 'user', 'group', 'region', or 'raw'
+            aggregate_by - 'month', 'day', 'none'. Must be 'none' if group_by='raw'
+        """
         args = {}
         args['start_date'] = start_date.strftime('%Y/%m/%d %H:%M:%S')
         args['end_date'] = end_date.strftime('%Y/%m/%d %H:%M:%S')

--- a/unit_tests/report_tests.py
+++ b/unit_tests/report_tests.py
@@ -1,0 +1,34 @@
+from dxskytap import Skytap
+import unittest
+import datetime
+class TestReports(unittest.TestCase):
+    def setUp(self):
+        self.root = Skytap()
+        self.reports = self.root.reports()
+
+    def test_generateReadReport(self):
+        midnight = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
+        sdate = midnight - datetime.timedelta(days=2)
+        edate = midnight - datetime.timedelta(days=1)
+        rpt = self.reports.generate_usage_report(sdate, edate, region='US-East', group_by='user', aggregate_by='day')
+        rpt.wait_for(30, 30)
+        reader = rpt.get_reader()
+        count = 0
+        maxlen = 0
+        for line in reader:
+            if len(line) > maxlen:
+                maxlen = len(line)
+            count  = count + 1
+        self.assertGreater(count, 0, 'Report contains zero rows')
+        self.assertGreater(maxlen, 0, 'Report rows all blank')
+
+    def tearDown(self):
+        pass
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(TestProjects('test_generateReadReport'))
+    return suite
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Last weeks change to dxskytap to support TLS v1.1+ broke the reporting api. The issue was not discovered earlier, because unit tests in dxskytap didn't include any tests for the report generation section of the api.

Fix the generate report call, and add test for generating usage report.